### PR TITLE
parser: add an option to keep tags across multiple documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
 
 **Features**:
 
+- Tags can now be retained across documents by calling `keep_tags(true)` on a
+  `yaml_rust2::Parser` before loading documents.
+  ([#10](https://github.com/Ethiraric/yaml-rust2/issues/10)
+  ([#12](https://github.com/Ethiraric/yaml-rust2/pull/12))
+
 **Development**:
 
 ## v0.7.0

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1126,5 +1126,9 @@ baz: "qux"
         assert_eq!(yaml["foo"].as_str(), Some("bar"));
         let yaml = &loader.documents()[1];
         assert_eq!(yaml["baz"].as_str(), Some("qux"));
+
+        let mut loader = YamlLoader::default()
+        let mut parser = Parser::new(text.chars()).keep_tags(false);
+        assert!(parser.load(&mut loader, true).is_err());
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -228,7 +228,28 @@ impl<T: Iterator<Item = char>> Parser<T> {
         }
     }
 
-    /// Make tags persistent when parsing multiple documents.
+    /// Whether to keep tags across multiple documents when parsing.
+    ///
+    /// This behavior is non-standard as per the YAML specification but can be encountered in the
+    /// wild. This boolean allows enabling this non-standard extension. This would result in the
+    /// parser accepting input from [test
+    /// QLJ7](https://github.com/yaml/yaml-test-suite/blob/ccfa74e56afb53da960847ff6e6976c0a0825709/src/QLJ7.yaml)
+    /// of the yaml-test-suite:
+    ///
+    /// ```yaml
+    /// %TAG !prefix! tag:example.com,2011:
+    /// --- !prefix!A
+    /// a: b
+    /// --- !prefix!B
+    /// c: d
+    /// --- !prefix!C
+    /// e: f
+    /// ```
+    ///
+    /// With `keep_tags` set to `false`, the above YAML is rejected. As per the specification, tags
+    /// only apply to the document immediately following them. This would error on `!prefix!B`.
+    ///
+    /// With `keep_tags` set to `true`, the above YAML is accepted by the parser.
     #[must_use]
     pub fn keep_tags(mut self, value: bool) -> Self {
         self.keep_tags = value;

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -239,6 +239,12 @@ impl YamlLoader {
         parser.load(&mut loader, true)?;
         Ok(loader.docs)
     }
+
+    /// Return a reference to the parsed Yaml documents.
+    #[must_use]
+    pub fn documents(&self) -> &[Yaml] {
+        &self.docs
+    }
 }
 
 /// The signature of the function to call when using [`YAMLDecodingTrap::Call`].


### PR DESCRIPTION
Documents are self-contained and tags defined in the first document are not visible to subsequent documents.

Add support for having tags that span across all documents by making the clearing of tags in the parser opt-out.

Closes: #10