### PR TITLE
Add linguist attributes for `tests/*.rs.inc` files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/*.rs.inc linguist-language=Rust linguist-generated


### PR DESCRIPTION
Made https://github.com/chyh1990/yaml-rust/pull/199, but I'm making it here, too.

This informs Linguist (used by GitHub) that these files are generated Rust files (they are currently detected as C++). This affects both language statistics and syntax highlighting.

Generated files will be "minimized" in a PR diff by default. If you would like to manually review these files whenever they are changed, you might want the `linguist-generated` attribute removed.