### PR TITLE
Fix multiline string emit.

### DIFF
--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -169,7 +169,7 @@ impl<'a> YamlEmitter<'a> {
     /// emitter.dump(&parsed[0]).unwrap();
     /// assert_eq!(output.as_str(), "\
     /// ---
-    /// foo: |
+    /// foo: |-
     ///   bar!
     ///   bar!
     /// baz: 42");
@@ -217,15 +217,7 @@ impl<'a> YamlEmitter<'a> {
                     && v.contains('\n')
                     && char_traits::is_valid_literal_block_scalar(v)
                 {
-                    write!(self.writer, "|")?;
-                    self.level += 1;
-                    for line in v.lines() {
-                        writeln!(self.writer)?;
-                        self.write_indent()?;
-                        // It's literal text, so don't escape special chars.
-                        write!(self.writer, "{line}")?;
-                    }
-                    self.level -= 1;
+                    self.emit_literal_block(v)?;
                 } else if need_quotes(v) {
                     escape_str(self.writer, v)?;
                 } else {
@@ -256,6 +248,26 @@ impl<'a> YamlEmitter<'a> {
             // XXX(chenyh) Alias
             Yaml::Alias(_) => Ok(()),
         }
+    }
+
+    fn emit_literal_block(&mut self, v: &str) -> EmitResult {
+        let ends_with_newline = v.ends_with('\n');
+        if ends_with_newline {
+            write!(self.writer, "|")?;
+        } else {
+            write!(self.writer, "|-")?;
+        }
+
+        self.level += 1;
+        // lines() will omit the last line if it is empty.
+        for line in v.lines() {
+            writeln!(self.writer)?;
+            self.write_indent()?;
+            // It's literal text, so don't escape special chars.
+            write!(self.writer, "{line}")?;
+        }
+        self.level -= 1;
+        Ok(())
     }
 
     fn emit_array(&mut self, v: &[Yaml]) -> EmitResult {

--- a/tests/test_round_trip.rs
+++ b/tests/test_round_trip.rs
@@ -13,6 +13,19 @@ fn roundtrip(original: &Yaml) {
     assert_eq!(documents[0], *original);
 }
 
+fn roundtrip_multiline(original: &Yaml) {
+    let mut emitted = String::new();
+    let mut emitter = YamlEmitter::new(&mut emitted);
+    emitter.multiline_strings(true);
+    emitter.dump(original).unwrap();
+
+    let documents = YamlLoader::load_from_str(&emitted).unwrap();
+    println!("emitted {emitted}");
+
+    assert_eq!(documents.len(), 1);
+    assert_eq!(documents[0], *original);
+}
+
 fn double_roundtrip(original: &str) {
     let parsed = YamlLoader::load_from_str(original).unwrap();
 
@@ -79,4 +92,28 @@ fn test_newline() {
 fn test_crlf() {
     let y = Yaml::Array(vec![Yaml::String("\r\n".to_owned())]);
     roundtrip(&y);
+}
+
+#[test]
+fn test_multiline_noline() {
+    let y = Yaml::Array(vec![Yaml::String("a".to_owned())]);
+    roundtrip_multiline(&y);
+}
+
+#[test]
+fn test_multiline_inner_newline() {
+    let y = Yaml::Array(vec![Yaml::String("a\nb".to_owned())]);
+    roundtrip_multiline(&y);
+}
+
+#[test]
+fn test_multiline_trailing_newline() {
+    let y = Yaml::Array(vec![Yaml::String("a\n".to_owned())]);
+    roundtrip_multiline(&y);
+}
+
+#[test]
+fn test_multiline_leading_newline() {
+    let y = Yaml::Array(vec![Yaml::String("\na".to_owned())]);
+    roundtrip_multiline(&y);
 }


### PR DESCRIPTION
Use `|-` instead of `|` when there is not a trailing newline in the string value.