### PR TITLE
Parse `.NaN` as float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Upcoming
 
+**Breaking changes**
+- Parse `.NaN` as float instead of `NaN`.
+
 ## v0.10.0
 
 **Breaking Changes**
@@ -54,7 +57,7 @@
     `Yaml::Hash` for `&'a str`
 
 - Use cargo features
-  
+
   This allows for more fine-grained control over MSRV and to completely remove
   debug code from the library when it is consumed.
 

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -67,7 +67,7 @@ fn parse_f64(v: &str) -> Option<f64> {
     match v {
         ".inf" | ".Inf" | ".INF" | "+.inf" | "+.Inf" | "+.INF" => Some(f64::INFINITY),
         "-.inf" | "-.Inf" | "-.INF" => Some(f64::NEG_INFINITY),
-        ".nan" | "NaN" | ".NAN" => Some(f64::NAN),
+        ".nan" | ".NaN" | ".NAN" => Some(f64::NAN),
         _ => v.parse::<f64>().ok(),
     }
 }


### PR DESCRIPTION
but no longer consider `NaN` a float.

Fixes #43.

Also, I guess this is a breaking change?