### PR TITLE
Restrict parsing of floating-point barewords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Upcoming
 
+- Parse `(?i)[+-]?(?:inf|infinity|nan)` as strings instead of floats
+
 ## v0.10.1
 
 **Bug fixes**

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -68,7 +68,10 @@ fn parse_f64(v: &str) -> Option<f64> {
         ".inf" | ".Inf" | ".INF" | "+.inf" | "+.Inf" | "+.INF" => Some(f64::INFINITY),
         "-.inf" | "-.Inf" | "-.INF" => Some(f64::NEG_INFINITY),
         ".nan" | ".NaN" | ".NAN" => Some(f64::NAN),
-        _ => v.parse::<f64>().ok(),
+        // Test that `v` contains a digit so as not to pass in strings like `inf`,
+        // which rust will parse as a float
+        _ if v.as_bytes().into_iter().any(|b| b.is_ascii_digit()) => v.parse::<f64>().ok(),
+        _ => None,
     }
 }
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -487,3 +487,38 @@ a: foo
 a: bar";
     assert!(YamlLoader::load_from_str(s).is_err());
 }
+
+#[test]
+fn test_nominal_float_parse() {
+    // back test for
+    // https://github.com/Ethiraric/yaml-rust2/issues/50
+
+    // Test cases derived from https://doc.rust-lang.org/std/primitive.f64.html#impl-FromStr-for-f64
+
+    // Generates a document that looks like so:
+    // ```yaml
+    // - +nan
+    // - -nan
+    // - nan
+    // - +NAN
+    // ```
+    // Every single one of these values should be parsed as a string in yaml,
+    // but would be parsed as a float according to rust. This test verifies they
+    // all end up parsed as strings.
+    let raw = &["nan", "NAN", "NaN", "inf", "infinity", "Infinity"]
+        .into_iter()
+        .map(|base| [format!("+{base}"), format!("-{base}"), base.to_string()])
+        .flatten()
+        .map(|v| format!("- {v}\n"))
+        .collect::<String>();
+
+    println!("parsing {raw}");
+
+    let doc = YamlLoader::load_from_str(&raw).expect("could not parse document");
+
+    assert!(doc[0].is_array());
+
+    for it in doc[0].clone().into_iter() {
+        assert!(it.as_str().is_some());
+    }
+}


### PR DESCRIPTION
Closes #50.

# Summary of the Issue

Currently, we use Rust's standard `f64` parsing to determine if a value is a float.

The [Rust docs](https://doc.rust-lang.org/std/primitive.f64.html#impl-FromStr-for-f64) provide the following EBNF grammar for what it considers to be valid floats:

```EBNF
Float  ::= Sign? ( 'inf' | 'infinity' | 'nan' | Number )
Number ::= ( Digit+ |
             Digit+ '.' Digit* |
             Digit* '.' Digit+ ) Exp?
Exp    ::= 'e' Sign? Digit+
Sign   ::= [+-]
Digit  ::= [0-9]
```

Meanwhile, the [YAML specification](https://yaml.org/spec/1.2.2/#10214-floating-point) provides this, conflicting, definition (in 10.2.1.4):
> Either `0`, `.inf`, `-.inf`, `.nan`, or scientific notation matching the regular expression `-? [1-9] ( \. [0-9]* [1-9] )? ( e [-+] [1-9] [0-9]* )?`.

Under the above rules, Rust considers any capitalization of `inf`, `infinity`, and `nan` to be floats, while YAML does not.

# Resolution

When parsing floats, before forwarding to Rust's parser, we now check if any character in the string is a digit. Referencing the regular expression from the YAML spec, we see this check will never reject valid floats.

While somewhat clunky inline, these changes resolve the issue we see. Also, because we can search raw UTF-8 bytes, instead of code points, my expectation is that this should auto-vectorize well. 

# Tests

I also added a `basic` test that generates several different variants of strings Rust considers to be floats, but YAML should not, and verifies they are all parsed as strings. I placed these tests under `tests/basic.rs`. Please let me know if that is not the correct location.
