### PR TITLE
Lower MSRV to Rust 1.65.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,13 @@ jobs:
     name: Lints and checks
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal --component rustfmt --component clippy --no-self-update
-      - run: cargo install cargo-msrv garden-tools
+      - run: date +%W >weekly
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ runner.os }}-lints-${{ hashFiles('weekly') }}
+      - run: cargo install cargo-msrv garden-tools
       - name: Run clippy checks
         run: garden check/clippy -vv
       - name: Run format checks
@@ -33,11 +35,13 @@ jobs:
         rust: [stable]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - run: git submodule update --init
+      - uses: actions/checkout@v4
+      - run: git submodule update --init --depth=1
       - run: rustup toolchain install ${{ matrix.rust }} --profile minimal --no-self-update
+      - run: date +%W >weekly
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.rust }}-${{ matrix.os }}-test-${{ hashFiles('weekly') }}
       - name: Run build
         run: cargo build
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches:
+      - dev
       - master
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal --component rustfmt --component clippy --no-self-update
-      - run: cargo install garden-tools
+      - run: cargo install cargo-msrv garden-tools
       - uses: Swatinem/rust-cache@v2
       - name: Run clippy checks
         run: garden check/clippy -vv
       - name: Run format checks
         run: garden check/fmt -vv
+      - name: Rust MSRV check
+        run: garden check/msrv -vv
 
   test:
     name: Test using Rust ${{ matrix.rust }} on ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal --component rustfmt --component clippy --no-self-update
+      - run: cargo install garden-tools
       - uses: Swatinem/rust-cache@v2
       - name: Run clippy checks
-        run: cargo clippy --all-targets -- -D warnings
+        run: garden check/clippy -vv
       - name: Run format checks
-        run: cargo fmt --check
+        run: garden check/fmt -vv
 
   test:
     name: Test using Rust ${{ matrix.rust }} on ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,12 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal --component rustfmt --component clippy --no-self-update
       - run: date +%W >weekly
-      - uses: Swatinem/rust-cache@v2
+      - id: cache
+        uses: Swatinem/rust-cache@v2
         with:
           key: ${{ runner.os }}-lints-${{ hashFiles('weekly') }}
-      - run: cargo install cargo-msrv garden-tools
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: cargo install cargo-msrv garden-tools
       - name: Run clippy checks
         run: garden check/clippy -vv
       - name: Run format checks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = "A fully YAML 1.2 compliant YAML parser"
 repository = "https://github.com/Ethiraric/yaml-rust2"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.65.0"
 
 [features]
 default = [ "encoding" ]

--- a/garden.yaml
+++ b/garden.yaml
@@ -21,6 +21,7 @@ commands:
     if type cargo-msrv >/dev/null 2>&1
     then
         cargo msrv verify
+        cargo msrv verify --rust-version 1.70.0 --features debug_prints
     fi
   check/profile: |
     cargo build \

--- a/garden.yaml
+++ b/garden.yaml
@@ -13,9 +13,15 @@ commands:
     - check/fmt
     - build
     - test
+    - check/msrv
     - check/profile
   check/clippy: cargo clippy --all-targets "$@" -- -D warnings
   check/fmt: cargo fmt --check
+  check/msrv: |
+    if type cargo-msrv >/dev/null 2>&1
+    then
+        cargo msrv verify
+    fi
   check/profile: |
     cargo build \
         --profile=release-lto \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! #### `encoding` (_enabled by default_)
 //! Enables encoding-aware decoding of Yaml documents.
 //!
-//! The MSRV for this feature is `1.70.0`.
+//! The MSRV for this feature is `1.65.0`.
 //!
 //! #### `debug_prints`
 //! Enables the `debug` module and usage of debug prints in the scanner and the parser. Do not

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -2459,7 +2459,12 @@ impl<T: Iterator<Item = char>> Scanner<T> {
     /// An indentation is not added if we are inside a flow level or if the last indent is already
     /// a non-block indent.
     fn roll_one_col_indent(&mut self) {
-        if self.flow_level == 0 && self.indents.last().is_some_and(|x| x.needs_block_end) {
+        if self.flow_level == 0
+            && self
+                .indents
+                .last()
+                .map_or(false, |indent| indent.needs_block_end)
+        {
             self.indents.push(Indent {
                 indent: self.indent,
                 needs_block_end: false,

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -316,7 +316,7 @@ pub type YAMLDecodingTrapFn = fn(
 
 /// The behavior [`YamlDecoder`] must have when an decoding error occurs.
 #[cfg(feature = "encoding")]
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone)]
 pub enum YAMLDecodingTrap {
     /// Ignore the offending bytes, remove them from the output.
     Ignore,
@@ -327,6 +327,19 @@ pub enum YAMLDecodingTrap {
     /// Call the user-supplied function upon decoding malformation.
     Call(YAMLDecodingTrapFn),
 }
+
+impl PartialEq for YAMLDecodingTrap {
+    fn eq(&self, other: &YAMLDecodingTrap) -> bool {
+        match (self, other) {
+            (YAMLDecodingTrap::Call(self_fn), YAMLDecodingTrap::Call(other_fn)) => {
+                *self_fn as usize == *other_fn as usize
+            }
+            (x, y) => x == y,
+        }
+    }
+}
+
+impl Eq for YAMLDecodingTrap {}
 
 /// `YamlDecoder` is a `YamlLoader` builder that allows you to supply your own encoding error trap.
 /// For example, to read a YAML file while ignoring Unicode decoding errors you can set the


### PR DESCRIPTION
Add a `garden check/msrv` command that uses `cargo-msrv` to
verify the crate's declared MSRV. Run these same checks in CI.

Lower the minimum supported Rust version to 1.65.0 by implementing
PartialEq which cannot be derived in earlier Rust versions.

Resolves: #20 
Reported-by: @jasonish