### PR TITLE
Fix build with --no-default-features

### DIFF
--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -328,6 +328,7 @@ pub enum YAMLDecodingTrap {
     Call(YAMLDecodingTrapFn),
 }
 
+#[cfg(feature = "encoding")]
 impl PartialEq for YAMLDecodingTrap {
     fn eq(&self, other: &YAMLDecodingTrap) -> bool {
         match (self, other) {
@@ -339,6 +340,7 @@ impl PartialEq for YAMLDecodingTrap {
     }
 }
 
+#[cfg(feature = "encoding")]
 impl Eq for YAMLDecodingTrap {}
 
 /// `YamlDecoder` is a `YamlLoader` builder that allows you to supply your own encoding error trap.


### PR DESCRIPTION
This was broken by 143478adc6cfc8bf19ea71e846aefdc7e7d70cd7.

The build generates some warnings about unused imports, but I don't believe this is new.